### PR TITLE
wp_publish_post not checking for unique post slugs

### DIFF
--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1844,4 +1844,59 @@ class Tests_Post extends WP_UnitTestCase {
 		unstick_post( 3 );
 		$this->assertSameSets( array( 1, 2, 2 ), get_option( 'sticky_posts' ) );
 	}
+
+	/**
+	 * Ensure updated post have a different slug then already publish post with same name.
+	 *
+	 * @ticket 50447
+	 * @covers ::wp_update_post
+	 */
+	public function test_updated_draft_post_have_unique_slug_from_publish_post_with_same_title() {
+
+		// Publish post metainfo.
+		$post = array(
+			'post_name'   => 'test',
+			'post_title'  => 'test',
+			'post_status' => 'publish',
+		);
+
+		// Add post.
+		$post_id = wp_insert_post( $post );
+
+		// Testcase for publish post with $post_id
+		$this->assertSame( 102, $post_id );
+		$this->assertSame( 'test', get_post( $post_id )->post_name );
+		$this->assertSame( 'test', get_post( $post_id )->post_title );
+		$this->assertSame( 'publish', get_post( $post_id )->post_status );
+
+		// Draft post metainfo.
+		$draft_post = array(
+			'post_title'  => 'test',
+			'post_status' => 'draft',
+		);
+
+		// Add draft post.
+		$draft_post_id = wp_insert_post( $draft_post );
+
+		// Testcase for draft post with $draft_post_id.
+		$this->assertSame( 103, $draft_post_id );
+		$this->assertSame( 'test', get_post( $draft_post_id )->post_title );
+		$this->assertSame( 'draft', get_post( $draft_post_id )->post_status );
+
+		// Draft post update metainfo.
+		$draft_post_update_to_publish = array(
+			'ID'          => $draft_post_id,
+			'post_status' => 'publish',
+		);
+
+		// Update draft post.
+		$draft_update_id = wp_update_post( $draft_post_update_to_publish );
+
+		// Testcase for updated draft post.
+		$this->assertSame( 103, $draft_update_id );
+		$this->assertSame( 'test', get_post( $draft_update_id )->post_title );
+		$this->assertSame( 'publish', get_post( $draft_update_id )->post_status );
+		$this->assertSame( 'test-2', get_post( $draft_update_id )->post_name );
+		$this->assertNotSame( 'test', get_post( $draft_update_id )->post_name );
+	}
 }


### PR DESCRIPTION
Add testcase to ensure that post have different post slug then the published post which have same name, when current draft post status update to publish with wp_update_post function.

Testcase ensure that post slug is unique by following steps
1. insert post with title 'test' and post-status is 'publish'
2. insert post with title 'test' and post-status is 'draft' 

trac ticket: https://core.trac.wordpress.org/ticket/50447
