### PR TITLE
Remove multiple directory validation check from function `_register_theme_block_patterns`

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -378,7 +378,7 @@ function _register_theme_block_patterns() {
 	foreach ( $themes as $theme ) {
 		$dirpath = $theme->get_stylesheet_directory() . '/patterns/';
 
-		if ( ! file_exists( $dirpath ) ) {
+		if ( ! is_readable( $dirpath ) ) {
 			continue;
 		} else {
 			$files = glob( $dirpath . '*.php' );

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -377,10 +377,10 @@ function _register_theme_block_patterns() {
 
 	foreach ( $themes as $theme ) {
 		$dirpath = $theme->get_stylesheet_directory() . '/patterns/';
-		if ( ! is_dir( $dirpath ) || ! is_readable( $dirpath ) ) {
+
+		if ( ! file_exists( $dirpath ) ) {
 			continue;
-		}
-		if ( file_exists( $dirpath ) ) {
+		} else {
 			$files = glob( $dirpath . '*.php' );
 			if ( $files ) {
 				foreach ( $files as $file ) {

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -380,7 +380,7 @@ function _register_theme_block_patterns() {
 
 		if ( ! is_readable( $dirpath ) ) {
 			continue;
-		} else {
+		} 	
 			$files = glob( $dirpath . '*.php' );
 			if ( $files ) {
 				foreach ( $files as $file ) {


### PR DESCRIPTION
Trac Ticket -> https://core.trac.wordpress.org/ticket/58656
- ----
In the pull request (PR), the changes were made to remove the is_dir and is_readable checks. These checks were originally used to verify the availability of a directory. To streamline the code and avoid multiple checks, the file_exists function was used to validate the directory's existence.

To implement this, an if condition was added with the negation of the file_exists check. If the condition is met, the continue statement is executed, skipping the rest of the code. However, if the directory is valid, the remaining code is executed as usual.